### PR TITLE
Added social media-style captions with emojis and hashtags, global lo…

### DIFF
--- a/app/assets/stylesheets/pages/_in_canada.scss
+++ b/app/assets/stylesheets/pages/_in_canada.scss
@@ -229,9 +229,9 @@
   align-items: center;
   gap: 4px;
   padding: 0 0 5px;
-  font-size: 0.72rem;
+  font-size: 0.60rem;
   color: $cu-charcoal;
-  font-weight: 600;
+  font-weight: 400;
   overflow: hidden;
 
   i { color: $cu-red; font-size: 0.65rem; flex-shrink: 0; }
@@ -456,7 +456,7 @@
   align-items: baseline;
   justify-content: space-between;
   padding: 2px 0;
-  font-size: 0.78rem;
+  font-size: 0.65rem;
   color: $cu-charcoal;
 
   form { display: inline-flex; margin: 0; }
@@ -633,8 +633,8 @@
 // [HW] Author name — same bold navy as before, now sits right next to the avatar
 // [HW] ellipsis prevents long names from breaking the card layout on narrow columns
 .feed-grid__author-name {
-  font-size: 0.88rem;
-  font-weight: 700;
+  font-size: 0.80rem;
+  font-weight: 520;
   color: $cu-navy;
   white-space: nowrap;
   overflow: hidden;
@@ -728,9 +728,9 @@
 // [HW] min-height keeps all cards the same height even when a photo has no caption
 .feed-grid__caption {
   padding: 7px 0 14px;
-  font-size: 0.88rem;
+  font-size: 0.65rem;
   color: $cu-charcoal;
-  text-align: center;
+  text-align: left;
   min-height: 40px;
 }
 
@@ -830,5 +830,18 @@
   &:hover {
     background: darken($light-gray, 10%);
     color: $cu-charcoal;
+  }
+}
+
+// [HW] Hashtags inside photo captions — coloured blue to look like a social media link.
+// The format_caption helper (app/helpers/application_helper.rb) wraps every #word in
+// a <span class="caption-hashtag">, and this rule styles those spans.
+.caption-hashtag {
+  color: $cu-blue;
+  font-weight: 500;
+
+  &:hover {
+    text-decoration: underline;
+    cursor: default; // [HW] keeps the arrow cursor — hashtags look like links but go nowhere
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+  # [HW] format_caption: renders a photo caption with hashtags styled in blue.
+  # CSS alone cannot target words that start with # — something has to wrap them
+  # in an HTML element first. This helper does that on the server side (safer than
+  # doing it in JavaScript, because it avoids putting user text into innerHTML).
+  # Step 1: html_escape the raw text to prevent XSS (e.g. if a caption contained <script>).
+  # Step 2: wrap every #word in a <span class="caption-hashtag"> so CSS can colour it.
+  # Step 3: mark the result html_safe so Rails outputs the spans instead of escaping them.
+  def format_caption(text)
+    return "" if text.blank?
+    safe = ERB::Util.html_escape(text)
+    safe.gsub(/#(\w+)/, '<span class="caption-hashtag">#\1</span>').html_safe
+  end
 end

--- a/app/javascript/controllers/location_autocomplete_controller.js
+++ b/app/javascript/controllers/location_autocomplete_controller.js
@@ -17,10 +17,10 @@ export default class extends Controller {
     this.debounceTimer = setTimeout(() => this.fetchSuggestions(query), 300)
   }
 
-  // [HW] Hits Nominatim with countrycodes=ca (Canada only) and addressdetails=1
-  // [HW] so the structured address object is available for clean formatting
+  // [HW] Hits Nominatim with addressdetails=1 so the structured address object is available
+  // [HW] for clean formatting. No countrycodes restriction — searches the whole world.
   async fetchSuggestions(query) {
-    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=5&countrycodes=ca&addressdetails=1`
+    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=5&addressdetails=1`
     const res = await fetch(url, { headers: { "Accept-Language": "en" } })
     this.renderDropdown(await res.json())
   }

--- a/app/views/pages/in_canada.html.erb
+++ b/app/views/pages/in_canada.html.erb
@@ -87,7 +87,8 @@
                 </div>
 
                 <%# [HW] Caption row — centered below the photo in the bottom white area %>
-                <div class="feed-grid__caption"><%= photo.description %></div>
+                <%# [HW] format_caption wraps #hashtags in a span so CSS can colour them blue %>
+                <div class="feed-grid__caption"><%= format_caption(photo.description) %></div>
 
               </div>
 
@@ -126,7 +127,7 @@
                       <%# [HW] Author name + caption — bold name inline before the description %>
                       <p class="photo-card__desc">
                         <strong class="photo-card__author"><%= photo.user.display_name %></strong>
-                        <%= photo.description %>
+                        <%= format_caption(photo.description) %>
                       </p>
 
                       <%# [HW] Additional comments below — id is the Turbo Stream append target %>
@@ -234,7 +235,7 @@
               </div>
 
               <div class="photo-card__body">
-                <p class="photo-card__desc"><%= photo.description %></p>
+                <p class="photo-card__desc"><%= format_caption(photo.description) %></p>
               </div>
             </div>
           <% end %>
@@ -264,7 +265,7 @@
                 <div class="feed-modal__content">
                   <p class="photo-card__desc">
                     <strong class="photo-card__author"><%= current_user.display_name %></strong>
-                    <%= photo.description %>
+                    <%= format_caption(photo.description) %>
                   </p>
                 </div>
               </div>

--- a/db/migrate/20260324151921_add_location_to_photos.rb
+++ b/db/migrate/20260324151921_add_location_to_photos.rb
@@ -1,5 +1,0 @@
-class AddLocationToPhotos < ActiveRecord::Migration[8.1]
-  def change
-    add_column :photos, :location, :string
-  end
-end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,42 +115,79 @@ puts "Created #{User.count} users"
 # ---------------------------
 puts "Creating photos..."
 
-# Hardcoded captions per user — matched to photos by index order. MJR
+# Captions per user — matched to photos by index order.
+# Written in social media style with emojis and hashtags. MJR/HW
 photo_captions = {
   "Mario" => [
-    "First day getting ready for Canada!",
-    "Packing my bags - so excited!",
-    "Saying goodbye to friends",
-    "Airport vibes"
+    "First day getting ready for Canada! 🍁✈️ #CanadaBound #ExchangeYear #CantWait",
+    "Packing my bags — so excited I can barely breathe! 🎒😍 #Packing #AdventureAwaits #CanadaUniqueExchange",
+    "Saying goodbye to the best people 🥺❤️ See you in 5 months! #MissYouAlready #ExchangeLife #Goodbyes",
+    "Airport vibes loading ✈️🛫 Next stop: Canada! #AirportVibes #OffWeGo #ExchangeYear"
   ],
   "Helena" => [
-    "Arrived in Vancouver! The mountains are insane",
-    "First day at school - everyone is so nice",
-    "Weekend hike with my host family",
-    "Canadian breakfast hits different",
-    "Downtown Vancouver at night",
-    "Snow day!!"
+    "I MADE IT TO VANCOUVER 🍁🏔️ The mountains literally took my breath away #Vancouver #ExchangeYear #CanadaUniqueExchange",
+    "First day at school done! Everyone is SO nice here 😊🎒 #NewSchool #ExchangeLife #VancouverVibes",
+    "Weekend hike with my host family 🥾🌲 Nature therapy hits different in Canada #Hiking #NatureLovers #BCWild",
+    "Canadian breakfast >>> 🍁🥞 Maple syrup on everything, no notes #CanadianFood #MapleLife #Brunch",
+    "Downtown Vancouver at night is absolutely stunning ✨🌃 #Vancouver #CityLights #NightPhotography",
+    "SNOW DAY!! ❄️⛄ My first real snow and I am obsessed #SnowDay #WinterWonderland #VancouverSnow"
   ],
   "Niels" => [
-    "Toronto skyline from the CN Tower",
-    "Hockey game last night - incredible atmosphere",
-    "Maple syrup tasting at the market",
-    "Niagara Falls - worth the trip",
-    "Last week of school, bittersweet"
+    "Toronto skyline from the CN Tower 🏙️😮 I am SO small #CNTower #Toronto #ExchangeLife",
+    "Hockey game last night and my voice is GONE 🏒🇨🇦 Best atmosphere I have ever experienced #NHL #HockeyNight #Toronto",
+    "Maple syrup tasting at the market 🍁😋 I may have bought too many bottles #MapleLife #StLawrenceMarket #Toronto",
+    "NIAGARA FALLS 🌊🤯 Worth. Every. Second. #NiagaraFalls #Ontario #MustSee",
+    "Last week of school how is this already ending 🥺📚 Bittersweet does not even cover it #ExchangeYear #LastWeek #Bittersweet"
   ],
   "Manu" => [
-    "Missing Canadian winters already",
-    "Best memories from my exchange year",
-    "Final day at school",
-    "Goodbye Canada, hello Germany",
-    "One year later - still dreaming of Canada"
+    "Missing Canadian winters so much right now ❄️😭 Nothing compares #PostCanada #MissingCanada #HomeIsWhereTheSnowIs",
+    "Going through my photos and crying a little 🥺📸 Best year of my life #ExchangeYear #Memories #CanadaForever",
+    "Final day at school still not over it 🎓🥲 Thank you for everything Canada #FinalDay #Gratitude #ExchangeLife",
+    "Goodbye Canada, hello Germany 🇨🇦🇩🇪 Heart is staying behind #Bittersweet #ExchangeEnds #SeeYouSoon",
+    "One year later and I still dream about Canada every single night 🍁💭 #OneYearAnniversary #ForeverGrateful #CanadaUnique"
+  ]
+}
+
+# Locations per user — index matches the caption above (caption 0 → location 0).
+# All locations are in Canada to match the seed's Canada-focused context.
+# Each user is placed in a different Canadian city, with real high school names
+# used where the photo context fits a school setting. HW
+photo_locations = {
+  "Mario" => [
+    "Ottawa, ON, Canada",
+    "Ottawa, ON, Canada",
+    "Lisgar Collegiate Institute, Ottawa, ON",
+    "Ottawa Macdonald-Cartier International Airport, ON"
+  ],
+  "Helena" => [
+    "Vancouver, BC, Canada",
+    "Kitsilano Secondary School, Vancouver, BC",
+    "Grouse Mountain, BC, Canada",
+    "Vancouver, BC, Canada",
+    "Downtown Vancouver, BC, Canada",
+    "North Vancouver, BC, Canada"
+  ],
+  "Niels" => [
+    "CN Tower, Toronto, ON",
+    "Scotiabank Arena, Toronto, ON",
+    "St. Lawrence Market, Toronto, ON",
+    "Niagara Falls, ON, Canada",
+    "Northern Secondary School, Toronto, ON"
+  ],
+  "Manu" => [
+    "Montreal, QC, Canada",
+    "Montreal, QC, Canada",
+    "Westmount High School, Montreal, QC",
+    "Montreal-Trudeau International Airport, QC",
+    "Montreal, QC, Canada"
   ]
 }
 
 all_photos = []
 
 users.each do |folder, user|
-  captions = photo_captions[folder] || []
+  captions  = photo_captions[folder]  || []
+  locations = photo_locations[folder] || [] # look up the matching location list for this user
   # Scope photos to each user's own folder so users get their own images, not a shared pool. MJR
   user_photos = Dir.glob("#{SEEDS_IMAGES_PATH}/#{folder}/[Pp]hoto*").sort
 
@@ -158,6 +195,7 @@ users.each do |folder, user|
     file = user_photos[index % user_photos.length]
     photo = Photo.create!(
       description: caption,
+      location:    locations[index], # index keeps caption and location in sync
       user: user,
       shared: [true, true, false].sample
     )


### PR DESCRIPTION
Added social media-style captions with **emojis and hashtags**, blue hashtag styling via a Ruby helper, plus small adjustments on sizing/ font weight of captions and location. 

Global **location** data for all seed photos, and removed the Canada-only restriction from the location autocomplete.

