### PR TITLE
Unify gallery card formatting with community feed (#123)

### DIFF
--- a/app/assets/stylesheets/pages/_in_canada.scss
+++ b/app/assets/stylesheets/pages/_in_canada.scss
@@ -322,13 +322,13 @@
   min-height: 40px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  align-items: flex-start;
+  text-align: left;
 }
 
 // [HW] Caption text
 .photo-card__desc {
-  font-size: 0.8rem;
+  font-size: 0.65rem;
   color: $cu-charcoal;
   margin-bottom: 0.25rem;
 }
@@ -340,10 +340,10 @@
   margin-right: 4px;
 }
 
-// [HW] Icon bar on white card area above the photo — share left, edit+delete right
+// [HW] Icon bar on white card area above the photo — share, edit, delete right-aligned
 .photo-card__actions {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   padding: 4px 4px 6px;
 
@@ -358,8 +358,8 @@
 
 // [HW] Circular icon buttons — dark navy default, coloured on hover or when active
 .photo-action-btn {
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -367,7 +367,7 @@
   border-radius: 50%;
   background: none;
   color: $cu-navy;
-  font-size: 0.75rem;
+  font-size: 0.65rem;
   cursor: pointer;
   text-decoration: none;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
@@ -389,14 +389,14 @@
     }
   }
 
-  // [HW] Filled navy when photo is currently shared (active state)
+  // [HW] Light navy tint when photo is currently shared — readable but not dominant
   &--active {
-    background: $cu-navy;
-    color: $cu-white;
+    background: lighten($cu-navy, 60%);
+    color: $cu-navy;
     border-color: $cu-navy;
 
     &:hover {
-      background: darken($cu-navy, 8%);
+      background: lighten($cu-navy, 52%);
       border-color: darken($cu-navy, 8%);
     }
   }
@@ -802,7 +802,7 @@
   gap: 4px;
   padding: 0 0 6px;
   font-size: 0.72rem;
-  font-weight: 600;
+  font-weight: 400;
   color: $cu-charcoal;
 
   i { color: $cu-red; font-size: 0.65rem; }

--- a/app/views/pages/in_canada.html.erb
+++ b/app/views/pages/in_canada.html.erb
@@ -106,7 +106,25 @@
                       <i class="fa-solid fa-xmark"></i>
                     </button>
 
-                    <%# [HW] Location in the white frame above the image — right-aligned, top-right corner %>
+                    <%# [HW] Author row — mirrors index card: avatar (opens profile modal) + name %>
+                    <div class="feed-grid__author">
+                      <span onclick="event.stopPropagation()"
+                            data-bs-toggle="modal"
+                            data-bs-target="#avatar-modal-<%= photo.user.id %>"
+                            class="feed-grid__avatar-trigger"
+                            title="View <%= photo.user.name %>'s profile">
+                        <% if photo.user.avatar.attached? %>
+                          <%= image_tag photo.user.avatar, class: "feed-grid__avatar" %>
+                        <% else %>
+                          <span class="feed-grid__avatar feed-grid__avatar--placeholder">
+                            <i class="fa fa-user"></i>
+                          </span>
+                        <% end %>
+                      </span>
+                      <span class="feed-grid__author-name"><%= photo.user.name %></span>
+                    </div>
+
+                    <%# [HW] Location row — same position as index card, below author %>
                     <% if photo.location.present? %>
                       <div class="feed-modal__above-img">
                         <i class="fa-solid fa-location-dot"></i>
@@ -195,18 +213,9 @@
         <% @my_photos.each do |photo| %>
           <% if photo.image.attached? %>
             <div class="photo-card">
-              <%# [HW] Icon bar — location label left, share + edit + delete right %>
+              <%# [HW] Icon bar — share + edit + delete right-aligned %>
               <div class="photo-card__actions">
-                <%# [HW] Left side: location pin + truncated text (informational, not a button) %>
-                <div class="photo-card__actions-left">
-                  <% if photo.location.present? %>
-                    <span class="photo-card__location-label">
-                      <i class="fa-solid fa-location-dot"></i>
-                      <span><%= photo.location %></span>
-                    </span>
-                  <% end %>
-                </div>
-                <%# [HW] Right side: share moved here from left, alongside edit and delete %>
+                <%# [HW] Right side: share, edit, delete %>
                 <div class="photo-card__actions-right">
                   <%= link_to toggle_share_photo_path(photo),
                       data: { turbo_method: :patch },
@@ -226,6 +235,14 @@
                   <% end %>
                 </div>
               </div>
+
+              <%# [HW] Location row — sits below the icon bar, above the photo, matching feed card layout %>
+              <% if photo.location.present? %>
+                <div class="feed-grid__location">
+                  <i class="fa-solid fa-location-dot"></i>
+                  <span><%= photo.location %></span>
+                </div>
+              <% end %>
 
               <%# [HW] Wrapper makes the image a modal trigger — action buttons above are unaffected %>
               <div class="photo-card__img-wrap"


### PR DESCRIPTION
## Gallery / Formatting Fixes (#123)

### Gallery card index
- Moved location from the action-button row to its own dedicated row
  between the icons and the photo, matching the community feed layout
- Share/edit/delete icons are now right-aligned in their own row (no longer
  sharing space with the location label)
- Caption is now left-aligned and smaller (0.65rem, down from 0.8rem) to
  match community feed caption style

### Action icons gallery card
- Reduced icon button size from 32px to 26px circles (less intrusive)
- "Shared" active state changed from solid navy fill to a light navy tint
  with navy border — still clearly indicates on, without dominating the card

### Zoomed-in modal (community feed)
- Added avatar + author name row above the location in the photo modal,
  matching the index card layout; avatar is clickable and opens the profile card
- Location text in both modals (gallery + feed) is no longer bold
  (font-weight 400, matching the index card location style)
